### PR TITLE
Fix build and coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ script:
   - go test -v -race -covermode=atomic -coverprofile=coverage.out
 
 after_success:
-  - goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN
+  - goveralls -coverprofile=coverage.out -service=travis-ci

--- a/pat.go
+++ b/pat.go
@@ -100,12 +100,12 @@ type PatternServeMux struct {
 	NotFound http.Handler
 
 	// Handlers associates HTTP methods with path patterns handlers.
-	Handlers map[string][]*PatHandler
+	Handlers map[string][]*Handler
 }
 
 // New returns a new PatternServeMux.
 func New() *PatternServeMux {
-	return &PatternServeMux{Handlers: make(map[string][]*PatHandler)}
+	return &PatternServeMux{Handlers: make(map[string][]*Handler)}
 }
 
 // HandleHTTP matches r.URL.Path against its routing table using the rules

--- a/pat_test.go
+++ b/pat_test.go
@@ -40,7 +40,7 @@ func TestPatMatch(t *testing.T) {
 		{"/foo/x:name", "/foo/bar", false, nil},
 		{"/foo/x:name", "/foo/xbar", true, url.Values{":name": {"bar"}}},
 	} {
-		params, ok := (&PatHandler{pat: tt.pat}).Match(tt.u)
+		params, ok := (&Handler{pat: tt.pat}).Match(tt.u)
 		if !tt.match {
 			if ok {
 				t.Errorf("[%d] url %q matched pattern %q", i, tt.u, tt.pat)


### PR DESCRIPTION
There were some leftover in https://github.com/vinci-proxy/pat/commit/396ec5b4550cbd26fa54b8d5129ab08a75f272a4. I replaced the remaining `PatHandler` by `Handler` and fixed coverage as per https://github.com/vinci-proxy/layer/pull/5.
